### PR TITLE
Two tweaks for your consideration

### DIFF
--- a/lib/Makefile.rules
+++ b/lib/Makefile.rules
@@ -49,8 +49,12 @@ target: $(TARGET)
 %.lst: %.elf
 	objdump -d $< > $@
 
+# Pad rule added for compatibility with VirtualBox. Can be commented
+# out to save space for qemu or vmware
+
 %.img: %.elf
 	objcopy -O binary $< $@
+#	python $(METALKIT_LIB)/pad.py $@ 512
 
 # Stackable rules for processing data files
 

--- a/lib/apm.c
+++ b/lib/apm.c
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2009 Micah Dowty
+ * Copyright (c) 2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/apm.h
+++ b/lib/apm.h
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/bios.c
+++ b/lib/bios.c
@@ -9,7 +9,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/bios.h
+++ b/lib/bios.h
@@ -9,7 +9,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/boot.S
+++ b/lib/boot.S
@@ -35,7 +35,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -301,7 +301,7 @@ copy_enter32:
          *
          * When we're done copying, branch to entry32 while we're
          * still in protected mode. Also note that we do a long branch
-         * to its final address, not it's temporary BIOS_PTR() address.
+         * to its final address, not its temporary BIOS_PTR() address.
          */
 
         addl    $DISK_BUFFER_SIZE, BIOS_PTR(dest_address)

--- a/lib/boot.h
+++ b/lib/boot.h
@@ -8,7 +8,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/console.c
+++ b/lib/console.c
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -73,7 +73,7 @@ Console_WriteUInt32(uint32 num, int digits, char padding, int base, Bool suppres
 
    if (num == 0 && suppressZero) {
       if (padding) {
-	 Console_WriteChar(padding);
+         Console_WriteChar(padding);
       }
    } else {
       uint8 digit = num % base;

--- a/lib/console.h
+++ b/lib/console.h
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/console_vga.c
+++ b/lib/console_vga.c
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/console_vga.h
+++ b/lib/console_vga.h
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/datafile.h
+++ b/lib/datafile.h
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/gcc_support.c
+++ b/lib/gcc_support.c
@@ -11,7 +11,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/intr.c
+++ b/lib/intr.c
@@ -7,7 +7,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/intr.h
+++ b/lib/intr.h
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/io.h
+++ b/lib/io.h
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/keyboard.c
+++ b/lib/keyboard.c
@@ -7,7 +7,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/keyboard.h
+++ b/lib/keyboard.h
@@ -7,7 +7,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/math.h
+++ b/lib/math.h
@@ -7,7 +7,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/pad.py
+++ b/lib/pad.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# Takes a file name and a block size,
+# pads the file so its length is a multiple of that block size.
+# Needed for VirtualBox to recognize floppy images.
+# Python2 to match the other use of Python in metalkit
+import sys
+import os
+import io
+
+def ceildiv(x, y): # Like x // y, but rounds towards (+/-) infinity rather than 0
+        return -(-x // y)
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print("usage: {} file blocksize".format(sys.argv[0]))
+
+    filename = sys.argv[1]
+    blocksize = int(sys.argv[2])
+    file_len = os.stat(filename).st_size
+    blocks = ceildiv(file_len, blocksize)
+    new_size = blocks * blocksize
+    print("padding {} to {} bytes...".format(filename, new_size))
+    fd = io.open(filename, "r+")
+    fd.seek(new_size-1)
+    fd.write(unicode('\0'))

--- a/lib/pci.c
+++ b/lib/pci.c
@@ -8,7 +8,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/pci.h
+++ b/lib/pci.h
@@ -8,7 +8,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/timer.c
+++ b/lib/timer.c
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/timer.h
+++ b/lib/timer.h
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/types.h
+++ b/lib/types.h
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/vbe.c
+++ b/lib/vbe.c
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/lib/vbe.h
+++ b/lib/vbe.h
@@ -6,7 +6,7 @@
  * writing software that runs on the bare metal. Get the latest code
  * at http://svn.navi.cx/misc/trunk/metalkit/
  *
- * Copyright (c) 2008-2009 Micah Dowty
+ * Copyright (c) 2008-2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation


### PR DESCRIPTION
First commit updates the name in the comments, fixes an errant apostrophe and tab character. Second commit adds (but doesn't invoke) a python script that pads out the .img files to a 512-byte boundary, for compatibility with VirtualBox's wacky floppy disk image detection.